### PR TITLE
fix: incompatibilities with changes in the Fleetwise RegisterAccount API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ yarn-error.log
 __pycache__
 .DS_Store
 /tmp/
+.idea/
+*.iml

--- a/.gitignore
+++ b/.gitignore
@@ -57,5 +57,3 @@ yarn-error.log
 __pycache__
 .DS_Store
 /tmp/
-.idea/
-*.iml

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "2.50.0",
+      "version": "2.96.2",
       "type": "build"
     },
     {
@@ -102,7 +102,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "^2.50.0",
+      "version": "^2.96.2",
       "type": "peer"
     },
     {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -6,7 +6,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   license: 'MIT-0',
   copyrightOwner: 'Amazon.com, Inc. or its affiliates. All Rights Reserved.',
   copyrightPeriod: '',
-  cdkVersion: '2.50.0',
+  cdkVersion: '2.96.2',
   defaultReleaseBranch: 'main',
   name: 'cdk-aws-iotfleetwise',
   repositoryUrl: 'https://github.com/aws-samples/cdk-aws-iotfleetwise.git',

--- a/doc/api-python.md
+++ b/doc/api-python.md
@@ -13,6 +13,7 @@ cdk_aws_iotfleetwise.Campaign(
   scope: Construct,
   id: str,
   collection_scheme: CollectionScheme,
+  data_destination_configs: typing.List[DataDestinationConfig],
   name: str,
   signals: typing.List[CampaignSignal],
   target: Vehicle,
@@ -25,6 +26,7 @@ cdk_aws_iotfleetwise.Campaign(
 | <code><a href="#cdk-aws-iotfleetwise.Campaign.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
 | <code><a href="#cdk-aws-iotfleetwise.Campaign.Initializer.parameter.id">id</a></code> | <code>str</code> | *No description.* |
 | <code><a href="#cdk-aws-iotfleetwise.Campaign.Initializer.parameter.collectionScheme">collection_scheme</a></code> | <code><a href="#cdk-aws-iotfleetwise.CollectionScheme">CollectionScheme</a></code> | *No description.* |
+| <code><a href="#cdk-aws-iotfleetwise.Campaign.Initializer.parameter.dataDestinationConfigs">data_destination_configs</a></code> | <code>typing.List[<a href="#cdk-aws-iotfleetwise.DataDestinationConfig">DataDestinationConfig</a>]</code> | *No description.* |
 | <code><a href="#cdk-aws-iotfleetwise.Campaign.Initializer.parameter.name">name</a></code> | <code>str</code> | *No description.* |
 | <code><a href="#cdk-aws-iotfleetwise.Campaign.Initializer.parameter.signals">signals</a></code> | <code>typing.List[<a href="#cdk-aws-iotfleetwise.CampaignSignal">CampaignSignal</a>]</code> | *No description.* |
 | <code><a href="#cdk-aws-iotfleetwise.Campaign.Initializer.parameter.target">target</a></code> | <code><a href="#cdk-aws-iotfleetwise.Vehicle">Vehicle</a></code> | *No description.* |
@@ -47,6 +49,12 @@ cdk_aws_iotfleetwise.Campaign(
 ##### `collection_scheme`<sup>Required</sup> <a name="collection_scheme" id="cdk-aws-iotfleetwise.Campaign.Initializer.parameter.collectionScheme"></a>
 
 - *Type:* <a href="#cdk-aws-iotfleetwise.CollectionScheme">CollectionScheme</a>
+
+---
+
+##### `data_destination_configs`<sup>Required</sup> <a name="data_destination_configs" id="cdk-aws-iotfleetwise.Campaign.Initializer.parameter.dataDestinationConfigs"></a>
+
+- *Type:* typing.List[<a href="#cdk-aws-iotfleetwise.DataDestinationConfig">DataDestinationConfig</a>]
 
 ---
 
@@ -361,9 +369,7 @@ import cdk_aws_iotfleetwise
 cdk_aws_iotfleetwise.SignalCatalog(
   scope: Construct,
   id: str,
-  database: CfnDatabase,
   nodes: typing.List[SignalCatalogNode],
-  table: CfnTable,
   description: str = None,
   name: str = None
 )
@@ -373,9 +379,7 @@ cdk_aws_iotfleetwise.SignalCatalog(
 | --- | --- | --- |
 | <code><a href="#cdk-aws-iotfleetwise.SignalCatalog.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
 | <code><a href="#cdk-aws-iotfleetwise.SignalCatalog.Initializer.parameter.id">id</a></code> | <code>str</code> | *No description.* |
-| <code><a href="#cdk-aws-iotfleetwise.SignalCatalog.Initializer.parameter.database">database</a></code> | <code>aws_cdk.aws_timestream.CfnDatabase</code> | *No description.* |
 | <code><a href="#cdk-aws-iotfleetwise.SignalCatalog.Initializer.parameter.nodes">nodes</a></code> | <code>typing.List[<a href="#cdk-aws-iotfleetwise.SignalCatalogNode">SignalCatalogNode</a>]</code> | *No description.* |
-| <code><a href="#cdk-aws-iotfleetwise.SignalCatalog.Initializer.parameter.table">table</a></code> | <code>aws_cdk.aws_timestream.CfnTable</code> | *No description.* |
 | <code><a href="#cdk-aws-iotfleetwise.SignalCatalog.Initializer.parameter.description">description</a></code> | <code>str</code> | *No description.* |
 | <code><a href="#cdk-aws-iotfleetwise.SignalCatalog.Initializer.parameter.name">name</a></code> | <code>str</code> | *No description.* |
 
@@ -393,21 +397,9 @@ cdk_aws_iotfleetwise.SignalCatalog(
 
 ---
 
-##### `database`<sup>Required</sup> <a name="database" id="cdk-aws-iotfleetwise.SignalCatalog.Initializer.parameter.database"></a>
-
-- *Type:* aws_cdk.aws_timestream.CfnDatabase
-
----
-
 ##### `nodes`<sup>Required</sup> <a name="nodes" id="cdk-aws-iotfleetwise.SignalCatalog.Initializer.parameter.nodes"></a>
 
 - *Type:* typing.List[<a href="#cdk-aws-iotfleetwise.SignalCatalogNode">SignalCatalogNode</a>]
-
----
-
-##### `table`<sup>Required</sup> <a name="table" id="cdk-aws-iotfleetwise.SignalCatalog.Initializer.parameter.table"></a>
-
-- *Type:* aws_cdk.aws_timestream.CfnTable
 
 ---
 
@@ -912,6 +904,7 @@ import cdk_aws_iotfleetwise
 
 cdk_aws_iotfleetwise.CampaignProps(
   collection_scheme: CollectionScheme,
+  data_destination_configs: typing.List[DataDestinationConfig],
   name: str,
   signals: typing.List[CampaignSignal],
   target: Vehicle,
@@ -924,6 +917,7 @@ cdk_aws_iotfleetwise.CampaignProps(
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#cdk-aws-iotfleetwise.CampaignProps.property.collectionScheme">collection_scheme</a></code> | <code><a href="#cdk-aws-iotfleetwise.CollectionScheme">CollectionScheme</a></code> | *No description.* |
+| <code><a href="#cdk-aws-iotfleetwise.CampaignProps.property.dataDestinationConfigs">data_destination_configs</a></code> | <code>typing.List[<a href="#cdk-aws-iotfleetwise.DataDestinationConfig">DataDestinationConfig</a>]</code> | *No description.* |
 | <code><a href="#cdk-aws-iotfleetwise.CampaignProps.property.name">name</a></code> | <code>str</code> | *No description.* |
 | <code><a href="#cdk-aws-iotfleetwise.CampaignProps.property.signals">signals</a></code> | <code>typing.List[<a href="#cdk-aws-iotfleetwise.CampaignSignal">CampaignSignal</a>]</code> | *No description.* |
 | <code><a href="#cdk-aws-iotfleetwise.CampaignProps.property.target">target</a></code> | <code><a href="#cdk-aws-iotfleetwise.Vehicle">Vehicle</a></code> | *No description.* |
@@ -938,6 +932,16 @@ collection_scheme: CollectionScheme
 ```
 
 - *Type:* <a href="#cdk-aws-iotfleetwise.CollectionScheme">CollectionScheme</a>
+
+---
+
+##### `data_destination_configs`<sup>Required</sup> <a name="data_destination_configs" id="cdk-aws-iotfleetwise.CampaignProps.property.dataDestinationConfigs"></a>
+
+```python
+data_destination_configs: typing.List[DataDestinationConfig]
+```
+
+- *Type:* typing.List[<a href="#cdk-aws-iotfleetwise.DataDestinationConfig">DataDestinationConfig</a>]
 
 ---
 
@@ -1057,9 +1061,7 @@ vehicles: typing.List[Vehicle]
 import cdk_aws_iotfleetwise
 
 cdk_aws_iotfleetwise.SignalCatalogProps(
-  database: CfnDatabase,
   nodes: typing.List[SignalCatalogNode],
-  table: CfnTable,
   description: str = None,
   name: str = None
 )
@@ -1069,21 +1071,9 @@ cdk_aws_iotfleetwise.SignalCatalogProps(
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#cdk-aws-iotfleetwise.SignalCatalogProps.property.database">database</a></code> | <code>aws_cdk.aws_timestream.CfnDatabase</code> | *No description.* |
 | <code><a href="#cdk-aws-iotfleetwise.SignalCatalogProps.property.nodes">nodes</a></code> | <code>typing.List[<a href="#cdk-aws-iotfleetwise.SignalCatalogNode">SignalCatalogNode</a>]</code> | *No description.* |
-| <code><a href="#cdk-aws-iotfleetwise.SignalCatalogProps.property.table">table</a></code> | <code>aws_cdk.aws_timestream.CfnTable</code> | *No description.* |
 | <code><a href="#cdk-aws-iotfleetwise.SignalCatalogProps.property.description">description</a></code> | <code>str</code> | *No description.* |
 | <code><a href="#cdk-aws-iotfleetwise.SignalCatalogProps.property.name">name</a></code> | <code>str</code> | *No description.* |
-
----
-
-##### `database`<sup>Required</sup> <a name="database" id="cdk-aws-iotfleetwise.SignalCatalogProps.property.database"></a>
-
-```python
-database: CfnDatabase
-```
-
-- *Type:* aws_cdk.aws_timestream.CfnDatabase
 
 ---
 
@@ -1094,16 +1084,6 @@ nodes: typing.List[SignalCatalogNode]
 ```
 
 - *Type:* typing.List[<a href="#cdk-aws-iotfleetwise.SignalCatalogNode">SignalCatalogNode</a>]
-
----
-
-##### `table`<sup>Required</sup> <a name="table" id="cdk-aws-iotfleetwise.SignalCatalogProps.property.table"></a>
-
-```python
-table: CfnTable
-```
-
-- *Type:* aws_cdk.aws_timestream.CfnTable
 
 ---
 
@@ -1575,6 +1555,38 @@ def to_object() -> any
 
 
 
+### DataDestinationConfig <a name="DataDestinationConfig" id="cdk-aws-iotfleetwise.DataDestinationConfig"></a>
+
+#### Initializers <a name="Initializers" id="cdk-aws-iotfleetwise.DataDestinationConfig.Initializer"></a>
+
+```python
+import cdk_aws_iotfleetwise
+
+cdk_aws_iotfleetwise.DataDestinationConfig()
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#cdk-aws-iotfleetwise.DataDestinationConfig.toObject">to_object</a></code> | *No description.* |
+
+---
+
+##### `to_object` <a name="to_object" id="cdk-aws-iotfleetwise.DataDestinationConfig.toObject"></a>
+
+```python
+def to_object() -> any
+```
+
+
+
+
 ### NetworkFileDefinition <a name="NetworkFileDefinition" id="cdk-aws-iotfleetwise.NetworkFileDefinition"></a>
 
 #### Initializers <a name="Initializers" id="cdk-aws-iotfleetwise.NetworkFileDefinition.Initializer"></a>
@@ -1599,6 +1611,71 @@ cdk_aws_iotfleetwise.NetworkFileDefinition()
 ---
 
 ##### `to_object` <a name="to_object" id="cdk-aws-iotfleetwise.NetworkFileDefinition.toObject"></a>
+
+```python
+def to_object() -> any
+```
+
+
+
+
+### S3ConfigProperty <a name="S3ConfigProperty" id="cdk-aws-iotfleetwise.S3ConfigProperty"></a>
+
+#### Initializers <a name="Initializers" id="cdk-aws-iotfleetwise.S3ConfigProperty.Initializer"></a>
+
+```python
+import cdk_aws_iotfleetwise
+
+cdk_aws_iotfleetwise.S3ConfigProperty(
+  bucket_arn: str,
+  data_format: str = None,
+  prefix: str = None,
+  storage_compression_format: str = None
+)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#cdk-aws-iotfleetwise.S3ConfigProperty.Initializer.parameter.bucketArn">bucket_arn</a></code> | <code>str</code> | *No description.* |
+| <code><a href="#cdk-aws-iotfleetwise.S3ConfigProperty.Initializer.parameter.dataFormat">data_format</a></code> | <code>str</code> | *No description.* |
+| <code><a href="#cdk-aws-iotfleetwise.S3ConfigProperty.Initializer.parameter.prefix">prefix</a></code> | <code>str</code> | *No description.* |
+| <code><a href="#cdk-aws-iotfleetwise.S3ConfigProperty.Initializer.parameter.storageCompressionFormat">storage_compression_format</a></code> | <code>str</code> | *No description.* |
+
+---
+
+##### `bucket_arn`<sup>Required</sup> <a name="bucket_arn" id="cdk-aws-iotfleetwise.S3ConfigProperty.Initializer.parameter.bucketArn"></a>
+
+- *Type:* str
+
+---
+
+##### `data_format`<sup>Optional</sup> <a name="data_format" id="cdk-aws-iotfleetwise.S3ConfigProperty.Initializer.parameter.dataFormat"></a>
+
+- *Type:* str
+
+---
+
+##### `prefix`<sup>Optional</sup> <a name="prefix" id="cdk-aws-iotfleetwise.S3ConfigProperty.Initializer.parameter.prefix"></a>
+
+- *Type:* str
+
+---
+
+##### `storage_compression_format`<sup>Optional</sup> <a name="storage_compression_format" id="cdk-aws-iotfleetwise.S3ConfigProperty.Initializer.parameter.storageCompressionFormat"></a>
+
+- *Type:* str
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#cdk-aws-iotfleetwise.S3ConfigProperty.toObject">to_object</a></code> | *No description.* |
+
+---
+
+##### `to_object` <a name="to_object" id="cdk-aws-iotfleetwise.S3ConfigProperty.toObject"></a>
 
 ```python
 def to_object() -> any
@@ -1802,6 +1879,55 @@ cdk_aws_iotfleetwise.TimeBasedCollectionScheme(
 ---
 
 ##### `to_object` <a name="to_object" id="cdk-aws-iotfleetwise.TimeBasedCollectionScheme.toObject"></a>
+
+```python
+def to_object() -> any
+```
+
+
+
+
+### TimestreamConfigProperty <a name="TimestreamConfigProperty" id="cdk-aws-iotfleetwise.TimestreamConfigProperty"></a>
+
+#### Initializers <a name="Initializers" id="cdk-aws-iotfleetwise.TimestreamConfigProperty.Initializer"></a>
+
+```python
+import cdk_aws_iotfleetwise
+
+cdk_aws_iotfleetwise.TimestreamConfigProperty(
+  execution_role_arn: str,
+  timestream_table_arn: str
+)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#cdk-aws-iotfleetwise.TimestreamConfigProperty.Initializer.parameter.executionRoleArn">execution_role_arn</a></code> | <code>str</code> | *No description.* |
+| <code><a href="#cdk-aws-iotfleetwise.TimestreamConfigProperty.Initializer.parameter.timestreamTableArn">timestream_table_arn</a></code> | <code>str</code> | *No description.* |
+
+---
+
+##### `execution_role_arn`<sup>Required</sup> <a name="execution_role_arn" id="cdk-aws-iotfleetwise.TimestreamConfigProperty.Initializer.parameter.executionRoleArn"></a>
+
+- *Type:* str
+
+---
+
+##### `timestream_table_arn`<sup>Required</sup> <a name="timestream_table_arn" id="cdk-aws-iotfleetwise.TimestreamConfigProperty.Initializer.parameter.timestreamTableArn"></a>
+
+- *Type:* str
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#cdk-aws-iotfleetwise.TimestreamConfigProperty.toObject">to_object</a></code> | *No description.* |
+
+---
+
+##### `to_object` <a name="to_object" id="cdk-aws-iotfleetwise.TimestreamConfigProperty.toObject"></a>
 
 ```python
 def to_object() -> any

--- a/doc/api-typescript.md
+++ b/doc/api-typescript.md
@@ -744,6 +744,7 @@ const campaignProps: CampaignProps = { ... }
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#cdk-aws-iotfleetwise.CampaignProps.property.collectionScheme">collectionScheme</a></code> | <code><a href="#cdk-aws-iotfleetwise.CollectionScheme">CollectionScheme</a></code> | *No description.* |
+| <code><a href="#cdk-aws-iotfleetwise.CampaignProps.property.dataDestinationConfigs">dataDestinationConfigs</a></code> | <code><a href="#cdk-aws-iotfleetwise.DataDestinationConfig">DataDestinationConfig</a>[]</code> | *No description.* |
 | <code><a href="#cdk-aws-iotfleetwise.CampaignProps.property.name">name</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cdk-aws-iotfleetwise.CampaignProps.property.signals">signals</a></code> | <code><a href="#cdk-aws-iotfleetwise.CampaignSignal">CampaignSignal</a>[]</code> | *No description.* |
 | <code><a href="#cdk-aws-iotfleetwise.CampaignProps.property.target">target</a></code> | <code><a href="#cdk-aws-iotfleetwise.Vehicle">Vehicle</a></code> | *No description.* |
@@ -758,6 +759,16 @@ public readonly collectionScheme: CollectionScheme;
 ```
 
 - *Type:* <a href="#cdk-aws-iotfleetwise.CollectionScheme">CollectionScheme</a>
+
+---
+
+##### `dataDestinationConfigs`<sup>Required</sup> <a name="dataDestinationConfigs" id="cdk-aws-iotfleetwise.CampaignProps.property.dataDestinationConfigs"></a>
+
+```typescript
+public readonly dataDestinationConfigs: DataDestinationConfig[];
+```
+
+- *Type:* <a href="#cdk-aws-iotfleetwise.DataDestinationConfig">DataDestinationConfig</a>[]
 
 ---
 
@@ -878,21 +889,9 @@ const signalCatalogProps: SignalCatalogProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#cdk-aws-iotfleetwise.SignalCatalogProps.property.database">database</a></code> | <code>aws-cdk-lib.aws_timestream.CfnDatabase</code> | *No description.* |
 | <code><a href="#cdk-aws-iotfleetwise.SignalCatalogProps.property.nodes">nodes</a></code> | <code><a href="#cdk-aws-iotfleetwise.SignalCatalogNode">SignalCatalogNode</a>[]</code> | *No description.* |
-| <code><a href="#cdk-aws-iotfleetwise.SignalCatalogProps.property.table">table</a></code> | <code>aws-cdk-lib.aws_timestream.CfnTable</code> | *No description.* |
 | <code><a href="#cdk-aws-iotfleetwise.SignalCatalogProps.property.description">description</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cdk-aws-iotfleetwise.SignalCatalogProps.property.name">name</a></code> | <code>string</code> | *No description.* |
-
----
-
-##### `database`<sup>Required</sup> <a name="database" id="cdk-aws-iotfleetwise.SignalCatalogProps.property.database"></a>
-
-```typescript
-public readonly database: CfnDatabase;
-```
-
-- *Type:* aws-cdk-lib.aws_timestream.CfnDatabase
 
 ---
 
@@ -903,16 +902,6 @@ public readonly nodes: SignalCatalogNode[];
 ```
 
 - *Type:* <a href="#cdk-aws-iotfleetwise.SignalCatalogNode">SignalCatalogNode</a>[]
-
----
-
-##### `table`<sup>Required</sup> <a name="table" id="cdk-aws-iotfleetwise.SignalCatalogProps.property.table"></a>
-
-```typescript
-public readonly table: CfnTable;
-```
-
-- *Type:* aws-cdk-lib.aws_timestream.CfnTable
 
 ---
 
@@ -1352,6 +1341,38 @@ public toObject(): object
 
 
 
+### DataDestinationConfig <a name="DataDestinationConfig" id="cdk-aws-iotfleetwise.DataDestinationConfig"></a>
+
+#### Initializers <a name="Initializers" id="cdk-aws-iotfleetwise.DataDestinationConfig.Initializer"></a>
+
+```typescript
+import { DataDestinationConfig } from 'cdk-aws-iotfleetwise'
+
+new DataDestinationConfig()
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#cdk-aws-iotfleetwise.DataDestinationConfig.toObject">toObject</a></code> | *No description.* |
+
+---
+
+##### `toObject` <a name="toObject" id="cdk-aws-iotfleetwise.DataDestinationConfig.toObject"></a>
+
+```typescript
+public toObject(): object
+```
+
+
+
+
 ### NetworkFileDefinition <a name="NetworkFileDefinition" id="cdk-aws-iotfleetwise.NetworkFileDefinition"></a>
 
 #### Initializers <a name="Initializers" id="cdk-aws-iotfleetwise.NetworkFileDefinition.Initializer"></a>
@@ -1376,6 +1397,66 @@ new NetworkFileDefinition()
 ---
 
 ##### `toObject` <a name="toObject" id="cdk-aws-iotfleetwise.NetworkFileDefinition.toObject"></a>
+
+```typescript
+public toObject(): object
+```
+
+
+
+
+### S3ConfigProperty <a name="S3ConfigProperty" id="cdk-aws-iotfleetwise.S3ConfigProperty"></a>
+
+#### Initializers <a name="Initializers" id="cdk-aws-iotfleetwise.S3ConfigProperty.Initializer"></a>
+
+```typescript
+import { S3ConfigProperty } from 'cdk-aws-iotfleetwise'
+
+new S3ConfigProperty(bucketArn: string, dataFormat?: string, prefix?: string, storageCompressionFormat?: string)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#cdk-aws-iotfleetwise.S3ConfigProperty.Initializer.parameter.bucketArn">bucketArn</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#cdk-aws-iotfleetwise.S3ConfigProperty.Initializer.parameter.dataFormat">dataFormat</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#cdk-aws-iotfleetwise.S3ConfigProperty.Initializer.parameter.prefix">prefix</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#cdk-aws-iotfleetwise.S3ConfigProperty.Initializer.parameter.storageCompressionFormat">storageCompressionFormat</a></code> | <code>string</code> | *No description.* |
+
+---
+
+##### `bucketArn`<sup>Required</sup> <a name="bucketArn" id="cdk-aws-iotfleetwise.S3ConfigProperty.Initializer.parameter.bucketArn"></a>
+
+- *Type:* string
+
+---
+
+##### `dataFormat`<sup>Optional</sup> <a name="dataFormat" id="cdk-aws-iotfleetwise.S3ConfigProperty.Initializer.parameter.dataFormat"></a>
+
+- *Type:* string
+
+---
+
+##### `prefix`<sup>Optional</sup> <a name="prefix" id="cdk-aws-iotfleetwise.S3ConfigProperty.Initializer.parameter.prefix"></a>
+
+- *Type:* string
+
+---
+
+##### `storageCompressionFormat`<sup>Optional</sup> <a name="storageCompressionFormat" id="cdk-aws-iotfleetwise.S3ConfigProperty.Initializer.parameter.storageCompressionFormat"></a>
+
+- *Type:* string
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#cdk-aws-iotfleetwise.S3ConfigProperty.toObject">toObject</a></code> | *No description.* |
+
+---
+
+##### `toObject` <a name="toObject" id="cdk-aws-iotfleetwise.S3ConfigProperty.toObject"></a>
 
 ```typescript
 public toObject(): object
@@ -1567,6 +1648,52 @@ new TimeBasedCollectionScheme(period: Duration)
 ---
 
 ##### `toObject` <a name="toObject" id="cdk-aws-iotfleetwise.TimeBasedCollectionScheme.toObject"></a>
+
+```typescript
+public toObject(): object
+```
+
+
+
+
+### TimestreamConfigProperty <a name="TimestreamConfigProperty" id="cdk-aws-iotfleetwise.TimestreamConfigProperty"></a>
+
+#### Initializers <a name="Initializers" id="cdk-aws-iotfleetwise.TimestreamConfigProperty.Initializer"></a>
+
+```typescript
+import { TimestreamConfigProperty } from 'cdk-aws-iotfleetwise'
+
+new TimestreamConfigProperty(executionRoleArn: string, timestreamTableArn: string)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#cdk-aws-iotfleetwise.TimestreamConfigProperty.Initializer.parameter.executionRoleArn">executionRoleArn</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#cdk-aws-iotfleetwise.TimestreamConfigProperty.Initializer.parameter.timestreamTableArn">timestreamTableArn</a></code> | <code>string</code> | *No description.* |
+
+---
+
+##### `executionRoleArn`<sup>Required</sup> <a name="executionRoleArn" id="cdk-aws-iotfleetwise.TimestreamConfigProperty.Initializer.parameter.executionRoleArn"></a>
+
+- *Type:* string
+
+---
+
+##### `timestreamTableArn`<sup>Required</sup> <a name="timestreamTableArn" id="cdk-aws-iotfleetwise.TimestreamConfigProperty.Initializer.parameter.timestreamTableArn"></a>
+
+- *Type:* string
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#cdk-aws-iotfleetwise.TimestreamConfigProperty.toObject">toObject</a></code> | *No description.* |
+
+---
+
+##### `toObject` <a name="toObject" id="cdk-aws-iotfleetwise.TimestreamConfigProperty.toObject"></a>
 
 ```typescript
 public toObject(): object

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/node": "^14",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
-    "aws-cdk-lib": "2.50.0",
+    "aws-cdk-lib": "2.96.2",
     "constructs": "10.0.5",
     "eslint": "^8",
     "eslint-import-resolver-node": "^0.3.6",
@@ -61,7 +61,7 @@
     "typescript": "^4.7.3"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.50.0",
+    "aws-cdk-lib": "^2.96.2",
     "constructs": "^10.0.5"
   },
   "keywords": [

--- a/src/campaign.ts
+++ b/src/campaign.ts
@@ -50,12 +50,63 @@ export class CampaignSignal {
   }
 }
 
+
+export class DataDestinationConfig {
+
+  protected destinationConfig: object;
+
+  constructor() {
+    this.destinationConfig = {};
+  }
+
+  toObject(): object {
+    return (this.destinationConfig);
+  }
+}
+
+export class S3ConfigProperty extends DataDestinationConfig {
+
+  constructor(
+    bucketArn: string,
+    dataFormat?: string,
+    prefix?: string,
+    storageCompressionFormat?: string,
+  ) {
+    super();
+
+    this.destinationConfig = {
+      s3Config: {
+        bucketArn: bucketArn,
+        dataFormat: dataFormat,
+        prefix: prefix,
+        storageCompressionFormat: storageCompressionFormat,
+      },
+    };
+  }
+}
+
+export class TimestreamConfigProperty extends DataDestinationConfig {
+
+  constructor(
+    executionRoleArn: string,
+    timestreamTableArn: string) {
+    super();
+    this.destinationConfig = {
+      timestreamConfig: {
+        executionRoleArn: executionRoleArn,
+        timestreamTableArn: timestreamTableArn,
+      },
+    };
+  };
+}
+
 export interface CampaignProps {
   readonly name: string;
   readonly target: Vehicle;
   readonly collectionScheme: CollectionScheme;
   readonly signals: CampaignSignal[];
   readonly autoApprove?: boolean;
+  readonly dataDestinationConfigs: DataDestinationConfig[];
 }
 
 export class Campaign extends Construct {
@@ -79,6 +130,7 @@ export class Campaign extends Construct {
       properties: {
         name: this.name,
         signal_catalog_arn: this.target.vehicleModel.signalCatalog.arn,
+        data_destination_configs: JSON.stringify(props.dataDestinationConfigs.map(s => s.toObject())),
         target_arn: this.target.arn,
         collection_scheme: JSON.stringify(props.collectionScheme.toObject()),
         signals_to_collect: JSON.stringify(props.signals.map(s => s.toObject())),

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -5,7 +5,6 @@ import {
   aws_logs as logs,
 } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
-import { Boto3LayerVersion } from './boto3layerversion';
 import { HandlerRole } from './handlerrole';
 
 
@@ -21,8 +20,7 @@ export class Handler extends lambda.SingletonFunction {
       code: lambda.AssetCode.fromAsset(path.join(__dirname, '/../src/handlers')),
       handler: props.handler,
       timeout: cdk.Duration.seconds(300),
-      runtime: lambda.Runtime.PYTHON_3_9,
-      layers: [Boto3LayerVersion.getOrCreate(scope).lambdaLayer],
+      runtime: lambda.Runtime.PYTHON_3_11,
       role: HandlerRole.getOrCreate(scope).role,
       logRetention: logs.RetentionDays.ONE_DAY,
     });

--- a/src/handlers/campaignhandler.py
+++ b/src/handlers/campaignhandler.py
@@ -5,11 +5,11 @@ import time
 def on_event(event, context):
     print(f'on_event {event} {context}')
     request_type = event['RequestType']
-    if request_type == 'Create': 
+    if request_type == 'Create':
         return on_create(event)
-    if request_type == 'Update': 
+    if request_type == 'Update':
         return on_update(event)
-    if request_type == 'Delete': 
+    if request_type == 'Delete':
         return on_delete(event)
     raise Exception("Invalid request type: {request_type}")
 
@@ -17,16 +17,17 @@ def on_create(event):
     props = event["ResourceProperties"]
     print(f"create new resource with props {props}")
     client=boto3.client('iotfleetwise')
-    
+
     response = client.create_campaign(
       name = props['name'],
       signalCatalogArn = props['signal_catalog_arn'],
       targetArn = props['target_arn'],
       collectionScheme = json.loads(props['collection_scheme']),
-      signalsToCollect = json.loads(props['signals_to_collect'])
+      signalsToCollect = json.loads(props['signals_to_collect']),
+      dataDestinationConfigs=json.loads(props['data_destination_configs'])
     )
     print(f"create_campaign response {response}")
-    
+
     if props['auto_approve'] == 'true':
         retry_count = 10;
         delay = 2;
@@ -37,7 +38,7 @@ def on_create(event):
             if response['status'] == "WAITING_FOR_APPROVAL":
                 break
             time.sleep(delay)
-            retry_count = retry_count - 1            
+            retry_count = retry_count - 1
         print(f"approving the campaign {props['name']}")
         response = client.update_campaign(
           name = props['name'],

--- a/src/handlers/servicehandler.py
+++ b/src/handlers/servicehandler.py
@@ -3,11 +3,11 @@ import boto3
 def on_event(event, context):
     print(event)
     request_type = event['RequestType']
-    if request_type == 'Create': 
+    if request_type == 'Create':
         return on_create(event)
-    if request_type == 'Update': 
+    if request_type == 'Update':
         return on_update(event)
-    if request_type == 'Delete': 
+    if request_type == 'Delete':
         return on_delete(event)
     raise Exception(f"Invalid request type: {request_type}")
 
@@ -15,12 +15,7 @@ def on_create(event):
     props = event["ResourceProperties"]
     print(f"create new resource with props {props}")
     client=boto3.client('iotfleetwise')
-    response = client.register_account(
-        timestreamResources={
-            'timestreamDatabaseName': props['database_name'],
-            'timestreamTableName': props['table_name']
-        }
-    )
+    response = client.register_account()
     print(response)
     return {}
 
@@ -29,12 +24,7 @@ def on_update(event):
     props = event["ResourceProperties"]
     print(f"update resource {physical_id} with props {props}")
     client=boto3.client('iotfleetwise')
-    response = client.register_account(
-        timestreamResources={
-            'timestreamDatabaseName': props['database_name'],
-            'timestreamTableName': props['table_name']
-        }
-    )
+    response = client.register_account()
     print(response)
     return { 'PhysicalResourceId': physical_id }
 
@@ -49,13 +39,11 @@ def is_complete(event, context):
     print(f"is_complete for resource {physical_id} with props {props}")
     client=boto3.client('iotfleetwise')
     response = client.get_register_account_status()
-    if (response['accountStatus'] == 'REGISTRATION_PENDING' or 
-        response['iamRegistrationResponse']['registrationStatus'] == 'REGISTRATION_PENDING' or
-        response['timestreamRegistrationResponse']['registrationStatus'] == 'REGISTRATION_PENDING'):
+    if (response['accountStatus'] == 'REGISTRATION_PENDING' or
+        response['iamRegistrationResponse']['registrationStatus'] == 'REGISTRATION_PENDING'):
         return { 'IsComplete': False }
-    elif (response['accountStatus'] == 'REGISTRATION_FAILURE' or 
-        response['iamRegistrationResponse']['registrationStatus'] == 'REGISTRATION_FAILURE' or
-        response['timestreamRegistrationResponse']['registrationStatus'] == 'REGISTRATION_FAILURE'):
+    elif (response['accountStatus'] == 'REGISTRATION_FAILURE' or
+        response['iamRegistrationResponse']['registrationStatus'] == 'REGISTRATION_FAILURE'):
         raise Exception(f"IoT FleetWise registration has failed {response}")
 
     return { 'IsComplete': True }

--- a/src/integ.dbc.ts
+++ b/src/integ.dbc.ts
@@ -41,8 +41,6 @@ export class IntegTesting {
     });
 
     const signalCatalog = new ifw.SignalCatalog(stack, 'SignalCatalog', {
-      database,
-      table,
       description: 'my signal catalog',
       nodes,
     });

--- a/src/signalcatalog.ts
+++ b/src/signalcatalog.ts
@@ -1,7 +1,4 @@
 import * as cdk from 'aws-cdk-lib';
-import {
-  aws_timestream as ts,
-} from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { Handler } from './handler';
 import { Provider } from './provider';
@@ -63,8 +60,6 @@ export class SignalCatalogSensor extends SignalCatalogNode {
 export interface SignalCatalogProps {
   readonly name?: string;
   readonly description?: string;
-  readonly database: ts.CfnDatabase;
-  readonly table: ts.CfnTable;
   readonly nodes: SignalCatalogNode[];
 }
 
@@ -103,10 +98,6 @@ export class SignalCatalog extends Construct {
 
     const serviceResource = new cdk.CustomResource(this, 'ServiceResource', {
       serviceToken: provider.provider.serviceToken,
-      properties: {
-        database_name: props.database.databaseName,
-        table_name: props.table.tableName,
-      },
     });
 
     const serviceCatalogHandler = new Handler(this, 'ServiceCatalogHandler', {

--- a/test/__snapshots__/integ.snapshot.test.ts.snap
+++ b/test/__snapshots__/integ.snapshot.test.ts.snap
@@ -27,6 +27,28 @@ Object {
         },
         "auto_approve": true,
         "collection_scheme": "{\\"timeBasedCollectionScheme\\":{\\"periodMs\\":10000}}",
+        "data_destination_configs": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "[{\\"timestreamConfig\\":{\\"executionRoleArn\\":\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "TimestreamExecutionRole47469287",
+                  "Arn",
+                ],
+              },
+              "\\",\\"timestreamTableArn\\":\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "Table",
+                  "Arn",
+                ],
+              },
+              "\\"}}]",
+            ],
+          ],
+        },
         "name": "FwTimeBasedCampaign1",
         "signal_catalog_arn": Object {
           "Fn::Join": Array [
@@ -170,7 +192,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-us-east-1",
           },
-          "S3Key": "eb5b005c858404ea0c8f68098ed5dcdf5340e02461f149751d10f59c210d5ef8.zip",
+          "S3Key": "5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555.zip",
         },
         "Handler": "index.handler",
         "Role": Object {
@@ -179,7 +201,8 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
+        "Timeout": 900,
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -320,8 +343,6 @@ Object {
             "Arn",
           ],
         },
-        "database_name": "FleetWise",
-        "table_name": "FleetWise",
       },
       "Type": "AWS::CloudFormation::CustomResource",
       "UpdateReplacePolicy": "Delete",
@@ -336,21 +357,16 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-us-east-1",
           },
-          "S3Key": "5d05bc94ee2631533a6249b16ce96e597bb43e45d90cc14ac9c9eb4446b17626.zip",
+          "S3Key": "2a959aaf5a798f08ab70fcdd87c1b928827d3c690f5a36fba79efae0dbfae2f2.zip",
         },
         "Handler": "campaignhandler.on_event",
-        "Layers": Array [
-          Object {
-            "Ref": "iotfleetwiselayerversionBoto3F9BD5A37",
-          },
-        ],
         "Role": Object {
           "Fn::GetAtt": Array [
             "handlerroleRoleEEEB95D2",
             "Arn",
           ],
         },
-        "Runtime": "python3.9",
+        "Runtime": "python3.11",
         "Timeout": 300,
       },
       "Type": "AWS::Lambda::Function",
@@ -388,21 +404,16 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-us-east-1",
           },
-          "S3Key": "5d05bc94ee2631533a6249b16ce96e597bb43e45d90cc14ac9c9eb4446b17626.zip",
+          "S3Key": "2a959aaf5a798f08ab70fcdd87c1b928827d3c690f5a36fba79efae0dbfae2f2.zip",
         },
         "Handler": "fleethandler.on_event",
-        "Layers": Array [
-          Object {
-            "Ref": "iotfleetwiselayerversionBoto3F9BD5A37",
-          },
-        ],
         "Role": Object {
           "Fn::GetAtt": Array [
             "handlerroleRoleEEEB95D2",
             "Arn",
           ],
         },
-        "Runtime": "python3.9",
+        "Runtime": "python3.11",
         "Timeout": 300,
       },
       "Type": "AWS::Lambda::Function",
@@ -440,21 +451,16 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-us-east-1",
           },
-          "S3Key": "5d05bc94ee2631533a6249b16ce96e597bb43e45d90cc14ac9c9eb4446b17626.zip",
+          "S3Key": "2a959aaf5a798f08ab70fcdd87c1b928827d3c690f5a36fba79efae0dbfae2f2.zip",
         },
         "Handler": "servicehandler.is_complete",
-        "Layers": Array [
-          Object {
-            "Ref": "iotfleetwiselayerversionBoto3F9BD5A37",
-          },
-        ],
         "Role": Object {
           "Fn::GetAtt": Array [
             "handlerroleRoleEEEB95D2",
             "Arn",
           ],
         },
-        "Runtime": "python3.9",
+        "Runtime": "python3.11",
         "Timeout": 300,
       },
       "Type": "AWS::Lambda::Function",
@@ -492,21 +498,16 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-us-east-1",
           },
-          "S3Key": "5d05bc94ee2631533a6249b16ce96e597bb43e45d90cc14ac9c9eb4446b17626.zip",
+          "S3Key": "2a959aaf5a798f08ab70fcdd87c1b928827d3c690f5a36fba79efae0dbfae2f2.zip",
         },
         "Handler": "servicehandler.on_event",
-        "Layers": Array [
-          Object {
-            "Ref": "iotfleetwiselayerversionBoto3F9BD5A37",
-          },
-        ],
         "Role": Object {
           "Fn::GetAtt": Array [
             "handlerroleRoleEEEB95D2",
             "Arn",
           ],
         },
-        "Runtime": "python3.9",
+        "Runtime": "python3.11",
         "Timeout": 300,
       },
       "Type": "AWS::Lambda::Function",
@@ -544,21 +545,16 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-us-east-1",
           },
-          "S3Key": "5d05bc94ee2631533a6249b16ce96e597bb43e45d90cc14ac9c9eb4446b17626.zip",
+          "S3Key": "2a959aaf5a798f08ab70fcdd87c1b928827d3c690f5a36fba79efae0dbfae2f2.zip",
         },
         "Handler": "signalcataloghandler.on_event",
-        "Layers": Array [
-          Object {
-            "Ref": "iotfleetwiselayerversionBoto3F9BD5A37",
-          },
-        ],
         "Role": Object {
           "Fn::GetAtt": Array [
             "handlerroleRoleEEEB95D2",
             "Arn",
           ],
         },
-        "Runtime": "python3.9",
+        "Runtime": "python3.11",
         "Timeout": 300,
       },
       "Type": "AWS::Lambda::Function",
@@ -596,21 +592,16 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-us-east-1",
           },
-          "S3Key": "5d05bc94ee2631533a6249b16ce96e597bb43e45d90cc14ac9c9eb4446b17626.zip",
+          "S3Key": "2a959aaf5a798f08ab70fcdd87c1b928827d3c690f5a36fba79efae0dbfae2f2.zip",
         },
         "Handler": "vehiclehandler.on_event",
-        "Layers": Array [
-          Object {
-            "Ref": "iotfleetwiselayerversionBoto3F9BD5A37",
-          },
-        ],
         "Role": Object {
           "Fn::GetAtt": Array [
             "handlerroleRoleEEEB95D2",
             "Arn",
           ],
         },
-        "Runtime": "python3.9",
+        "Runtime": "python3.11",
         "Timeout": 300,
       },
       "Type": "AWS::Lambda::Function",
@@ -648,21 +639,16 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-us-east-1",
           },
-          "S3Key": "5d05bc94ee2631533a6249b16ce96e597bb43e45d90cc14ac9c9eb4446b17626.zip",
+          "S3Key": "2a959aaf5a798f08ab70fcdd87c1b928827d3c690f5a36fba79efae0dbfae2f2.zip",
         },
         "Handler": "vehiclemodelhandler.on_event",
-        "Layers": Array [
-          Object {
-            "Ref": "iotfleetwiselayerversionBoto3F9BD5A37",
-          },
-        ],
         "Role": Object {
           "Fn::GetAtt": Array [
             "handlerroleRoleEEEB95D2",
             "Arn",
           ],
         },
-        "Runtime": "python3.9",
+        "Runtime": "python3.11",
         "Timeout": 300,
       },
       "Type": "AWS::Lambda::Function",
@@ -700,6 +686,51 @@ Object {
       },
       "Type": "AWS::Timestream::Table",
     },
+    "TimestreamExecutionRole47469287": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "iotfleetwise.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Policies": Array [
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": Array [
+                    "timestream:WriteRecords",
+                    "timestream:Select",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": Object {
+                    "Fn::GetAtt": Array [
+                      "Table",
+                      "Arn",
+                    ],
+                  },
+                },
+                Object {
+                  "Action": "timestream:DescribeEndpoints",
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "permissionsPolicy",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
     "campaignhandleroneventproviderProviderframeworkonEventF0F8C6CC": Object {
       "DependsOn": Array [
         "campaignhandleroneventproviderProviderframeworkonEventServiceRoleDefaultPolicyF11C0596",
@@ -710,7 +741,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-us-east-1",
           },
-          "S3Key": "6ff23d2800aac27308e31c227529dc13854507c3b2598d2433fcf82604fa054d.zip",
+          "S3Key": "7382a0addb9f34974a1ea6c6c9b063882af874828f366f5c93b2b7b64db15c94.zip",
         },
         "Description": "AWS CDK resource provider framework - onEvent (integ-stack/campaignhandler.on_event-provider/Provider)",
         "Environment": Object {
@@ -730,7 +761,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Timeout": 900,
       },
       "Type": "AWS::Lambda::Function",
@@ -841,7 +872,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-us-east-1",
           },
-          "S3Key": "6ff23d2800aac27308e31c227529dc13854507c3b2598d2433fcf82604fa054d.zip",
+          "S3Key": "7382a0addb9f34974a1ea6c6c9b063882af874828f366f5c93b2b7b64db15c94.zip",
         },
         "Description": "AWS CDK resource provider framework - onEvent (integ-stack/fleethandler.on_event-provider/Provider)",
         "Environment": Object {
@@ -861,7 +892,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Timeout": 900,
       },
       "Type": "AWS::Lambda::Function",
@@ -1041,21 +1072,6 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "iotfleetwiselayerversionBoto3F9BD5A37": Object {
-      "Properties": Object {
-        "CompatibleRuntimes": Array [
-          "python3.9",
-        ],
-        "Content": Object {
-          "S3Bucket": Object {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-us-east-1",
-          },
-          "S3Key": "70f96227ddbb8dbfac3f1733fdeaed33b6c92e507e27290f011ebba21aacf939.zip",
-        },
-        "Description": "Boto3 Library with Iot Fleetwise Support",
-      },
-      "Type": "AWS::Lambda::LayerVersion",
-    },
     "servicehandleroneventproviderProviderframeworkisCompleteD1F225BF": Object {
       "DependsOn": Array [
         "servicehandleroneventproviderProviderframeworkisCompleteServiceRoleDefaultPolicy240ECF7D",
@@ -1066,7 +1082,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-us-east-1",
           },
-          "S3Key": "6ff23d2800aac27308e31c227529dc13854507c3b2598d2433fcf82604fa054d.zip",
+          "S3Key": "7382a0addb9f34974a1ea6c6c9b063882af874828f366f5c93b2b7b64db15c94.zip",
         },
         "Description": "AWS CDK resource provider framework - isComplete (integ-stack/servicehandler.on_event-provider/Provider)",
         "Environment": Object {
@@ -1092,7 +1108,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Timeout": 900,
       },
       "Type": "AWS::Lambda::Function",
@@ -1229,7 +1245,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-us-east-1",
           },
-          "S3Key": "6ff23d2800aac27308e31c227529dc13854507c3b2598d2433fcf82604fa054d.zip",
+          "S3Key": "7382a0addb9f34974a1ea6c6c9b063882af874828f366f5c93b2b7b64db15c94.zip",
         },
         "Description": "AWS CDK resource provider framework - onEvent (integ-stack/servicehandler.on_event-provider/Provider)",
         "Environment": Object {
@@ -1258,7 +1274,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Timeout": 900,
       },
       "Type": "AWS::Lambda::Function",
@@ -1402,7 +1418,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-us-east-1",
           },
-          "S3Key": "6ff23d2800aac27308e31c227529dc13854507c3b2598d2433fcf82604fa054d.zip",
+          "S3Key": "7382a0addb9f34974a1ea6c6c9b063882af874828f366f5c93b2b7b64db15c94.zip",
         },
         "Description": "AWS CDK resource provider framework - onTimeout (integ-stack/servicehandler.on_event-provider/Provider)",
         "Environment": Object {
@@ -1428,7 +1444,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Timeout": 900,
       },
       "Type": "AWS::Lambda::Function",
@@ -1687,7 +1703,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-us-east-1",
           },
-          "S3Key": "6ff23d2800aac27308e31c227529dc13854507c3b2598d2433fcf82604fa054d.zip",
+          "S3Key": "7382a0addb9f34974a1ea6c6c9b063882af874828f366f5c93b2b7b64db15c94.zip",
         },
         "Description": "AWS CDK resource provider framework - onEvent (integ-stack/signalcataloghandler.on_event-provider/Provider)",
         "Environment": Object {
@@ -1707,7 +1723,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Timeout": 900,
       },
       "Type": "AWS::Lambda::Function",
@@ -1818,7 +1834,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-us-east-1",
           },
-          "S3Key": "6ff23d2800aac27308e31c227529dc13854507c3b2598d2433fcf82604fa054d.zip",
+          "S3Key": "7382a0addb9f34974a1ea6c6c9b063882af874828f366f5c93b2b7b64db15c94.zip",
         },
         "Description": "AWS CDK resource provider framework - onEvent (integ-stack/vehiclehandler.on_event-provider/Provider)",
         "Environment": Object {
@@ -1838,7 +1854,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Timeout": 900,
       },
       "Type": "AWS::Lambda::Function",
@@ -1949,7 +1965,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-us-east-1",
           },
-          "S3Key": "6ff23d2800aac27308e31c227529dc13854507c3b2598d2433fcf82604fa054d.zip",
+          "S3Key": "7382a0addb9f34974a1ea6c6c9b063882af874828f366f5c93b2b7b64db15c94.zip",
         },
         "Description": "AWS CDK resource provider framework - onEvent (integ-stack/vehiclemodelhandler.on_event-provider/Provider)",
         "Environment": Object {
@@ -1969,7 +1985,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Timeout": 900,
       },
       "Type": "AWS::Lambda::Function",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,21 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+"@aws-cdk/asset-awscli-v1@^2.2.200":
+  version "2.2.200"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.200.tgz#6ead533f73f705ad7350eb46955e2538e50cd013"
+  integrity sha512-Kf5J8DfJK4wZFWT2Myca0lhwke7LwHcHBo+4TvWOGJrFVVKVuuiLCkzPPRBQQVDj0Vtn2NBokZAz8pfMpAqAKg==
+
+"@aws-cdk/asset-kubectl-v20@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz#d8e20b5f5dc20128ea2000dc479ca3c7ddc27248"
+  integrity sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg==
+
+"@aws-cdk/asset-node-proxy-agent-v6@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.1.tgz#6dc9b7cdb22ff622a7176141197962360c33e9ac"
+  integrity sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg==
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz#3b25d38c89600baa2dcc219edfa88a74eb2c427a"
@@ -1062,6 +1077,16 @@ ajv@^6.10.0, ajv@^6.12.4:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+ajv@^8.0.1:
+  version "8.12.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
+  integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
 ajv@^8.11.0:
   version "8.11.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
@@ -1189,6 +1214,11 @@ arrify@^1.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==
 
+astral-regex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
+  integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -1199,19 +1229,23 @@ at-least-node@^1.0.0:
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
-aws-cdk-lib@2.50.0:
-  version "2.50.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.50.0.tgz#2b3a9ba4c1c4c56fd32e3e4f57eea8bf9fa3dbba"
-  integrity sha512-deDbZTI7oyu3rqUyqjwhP6tnUO8MD70lE98yR65xiYty4yXBpsWKbeH3s1wNLpLAWS3hWJYyMtjZ4ZfC35NtVg==
+aws-cdk-lib@2.96.2:
+  version "2.96.2"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.96.2.tgz#d9647ad402525e92740df5a083777698698fd7de"
+  integrity sha512-wDAdPUfNlteLQKrapd5c7hNYHWPzHmFfuMSrddFCajjoscsnd0LeUxM2yAzwJV7vLNp00q2SgUZqRQHcN98dmg==
   dependencies:
+    "@aws-cdk/asset-awscli-v1" "^2.2.200"
+    "@aws-cdk/asset-kubectl-v20" "^2.1.2"
+    "@aws-cdk/asset-node-proxy-agent-v6" "^2.0.1"
     "@balena/dockerignore" "^1.0.2"
     case "1.6.3"
-    fs-extra "^9.1.0"
-    ignore "^5.2.0"
+    fs-extra "^11.1.1"
+    ignore "^5.2.4"
     jsonschema "^1.4.1"
     minimatch "^3.1.2"
-    punycode "^2.1.1"
-    semver "^7.3.8"
+    punycode "^2.3.0"
+    semver "^7.5.4"
+    table "^6.8.1"
     yaml "1.10.2"
 
 babel-jest@^27.5.1:
@@ -2520,6 +2554,15 @@ fs-extra@^10.1.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
+fs-extra@^11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.1.1.tgz#da69f7c39f3b002378b0954bb6ae7efdc0876e2d"
+  integrity sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs-extra@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
@@ -2953,6 +2996,11 @@ ignore@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
+
+ignore@^5.2.4:
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
+  integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
 
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"
@@ -4050,6 +4098,11 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
+lodash.truncate@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
+  integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
+
 lodash@^4.17.15, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
@@ -4923,6 +4976,11 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
+punycode@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.0.tgz#f67fa67c94da8f4d0cfff981aee4118064199b8f"
+  integrity sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==
+
 pupa@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/pupa/-/pupa-3.1.0.tgz#f15610274376bbcc70c9a3aa8b505ea23f41c579"
@@ -5258,6 +5316,13 @@ semver@^6.0.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
+semver@^7.5.4:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
+  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
+  dependencies:
+    lru-cache "^6.0.0"
+
 set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
@@ -5315,6 +5380,15 @@ slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
+
+slice-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b"
+  integrity sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==
+  dependencies:
+    ansi-styles "^4.0.0"
+    astral-regex "^2.0.0"
+    is-fullwidth-code-point "^3.0.0"
 
 smart-buffer@^4.2.0:
   version "4.2.0"
@@ -5615,6 +5689,17 @@ symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
+
+table@^6.8.1:
+  version "6.8.1"
+  resolved "https://registry.yarnpkg.com/table/-/table-6.8.1.tgz#ea2b71359fe03b017a5fbc296204471158080bdf"
+  integrity sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==
+  dependencies:
+    ajv "^8.0.1"
+    lodash.truncate "^4.4.2"
+    slice-ansi "^4.0.0"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
 
 tar@^6.1.11, tar@^6.1.2:
   version "6.1.11"


### PR DESCRIPTION
Fix incompatibilities with changes in the Fleetwise RegisterAccount API:

- Removed Timestream params from the register account SDK call. 
- Added support for data destinations in CreateCampaign as per docs.
- Bumped Lambda Python runtime to ensure usage of newer boto3.
- Bumped CDK version to be able to bump Lambda Python Runtime.
- Fixed tests and regenerated docs. 